### PR TITLE
Add initial quantum P2P skeleton

### DIFF
--- a/painet_common/__init__.py
+++ b/painet_common/__init__.py
@@ -1,0 +1,5 @@
+"""Common utilities for PAI Net."""
+from .protocol.messages import MessageType, QuantumEncryptedPayload, RouteInfo
+
+__all__ = ["MessageType", "QuantumEncryptedPayload", "RouteInfo"]
+

--- a/painet_common/protocol/__init__.py
+++ b/painet_common/protocol/__init__.py
@@ -1,0 +1,4 @@
+from .messages import MessageType, QuantumEncryptedPayload, RouteInfo
+
+__all__ = ["MessageType", "QuantumEncryptedPayload", "RouteInfo"]
+

--- a/painet_common/protocol/messages.py
+++ b/painet_common/protocol/messages.py
@@ -1,0 +1,44 @@
+"""Common protocol messages for Quantum P2P."""
+
+from enum import Enum
+from typing import Optional
+from pydantic import BaseModel, Field
+import time
+
+class MessageType(str, Enum):
+    NODE_ANNOUNCE = "node_announce"
+    NODE_QUERY = "node_query"
+    NODE_RESPONSE = "node_response"
+    MODEL_ANNOUNCE = "model_announce"
+    MODEL_REQUEST = "model_request"
+    MODEL_SHARD_TRANSFER = "model_shard_transfer"
+    MODEL_SYNC = "model_sync"
+    INFERENCE_REQUEST = "inference_request"
+    INFERENCE_RESPONSE = "inference_response"
+    PARTIAL_RESULT = "partial_result"
+    HEARTBEAT = "heartbeat"
+    NETWORK_UPDATE = "network_update"
+    RESULT_CONSENSUS = "result_consensus"
+    FAULT_NOTIFICATION = "fault_notification"
+    QUANTUM_KEY_EXCHANGE = "quantum_key_exchange"
+    QUANTUM_ENCRYPTED_MESSAGE = "quantum_encrypted_message"
+
+class QuantumEncryptedPayload(BaseModel):
+    encrypted_data: str = Field(..., description="Hex encoded")
+    quantum_signature: str = Field(..., description="HMAC signature")
+    entanglement_id: str = Field(...)
+    encryption_timestamp: float = Field(default_factory=time.time)
+    original_type: str = Field(...)
+    key_rotation_id: Optional[str] = None
+    nonce: str = Field(...)
+    sequence_number: int = Field(default=0)
+
+class RouteInfo(BaseModel):
+    route: list[str] = Field(default_factory=list)
+    confidence: float = 0.0
+    latency_estimate: float = 0.0
+    bandwidth_estimate: float = 0.0
+    failure_rate: float = 0.0
+    optimization_reason: str = ""
+
+__all__ = ["MessageType", "QuantumEncryptedPayload", "RouteInfo"]

--- a/ultimate_agent/network/__init__.py
+++ b/ultimate_agent/network/__init__.py
@@ -1,0 +1,3 @@
+"""Network utilities package."""
+
+__all__ = []

--- a/ultimate_agent/network/p2p/__init__.py
+++ b/ultimate_agent/network/p2p/__init__.py
@@ -13,13 +13,22 @@ from .distributed_ai import (
     NodeCapability
 )
 
+from .quantum_crypto import QuantumEncryptionProtocol
+from .adaptive_routing import CSPAdaptiveRouting
+from .fault_tolerance import CSPFaultTolerance
+from .quantum_enhanced_p2p import QuantumEnhancedP2PManager
+
 __all__ = [
     'P2PNetworkManager',
     'P2PDistributedAIIntegration', 
     'NodeType',
     'MessageType',
     'InferenceTask',
-    'NodeCapability'
+    'NodeCapability',
+    'QuantumEncryptionProtocol',
+    'CSPAdaptiveRouting',
+    'CSPFaultTolerance',
+    'QuantumEnhancedP2PManager'
 ]
 
 # File 2: ultimate_agent/network/p2p/integration.py

--- a/ultimate_agent/network/p2p/adaptive_routing.py
+++ b/ultimate_agent/network/p2p/adaptive_routing.py
@@ -1,0 +1,21 @@
+"""Simple adaptive routing placeholder."""
+
+from collections import defaultdict, deque
+from typing import List
+
+from painet_common.protocol.messages import MessageType, RouteInfo
+
+
+class CSPAdaptiveRouting:
+    def __init__(self, node_id: str):
+        self.node_id = node_id
+        self.history = defaultdict(lambda: deque(maxlen=10))
+
+    def find_optimal_route(self, target: str, msg_type: MessageType, peers: List[str]) -> RouteInfo:
+        if not peers:
+            return RouteInfo(route=[], confidence=0.0, optimization_reason="no peers")
+        peer = peers[0]
+        return RouteInfo(route=[self.node_id, peer, target], confidence=1.0, optimization_reason="default")
+
+    def record_route_performance(self, peer_id: str, latency_ms: float, bandwidth_mbps: float, success: bool):
+        self.history[peer_id].append(latency_ms)

--- a/ultimate_agent/network/p2p/fault_tolerance.py
+++ b/ultimate_agent/network/p2p/fault_tolerance.py
@@ -1,0 +1,27 @@
+"""Minimal fault tolerance utilities."""
+
+import asyncio
+from collections import defaultdict
+from typing import Any, Awaitable, Callable, Dict
+
+
+class CSPFaultTolerance:
+    def __init__(self, node_id: str):
+        self.node_id = node_id
+        self.failures = defaultdict(int)
+
+    async def execute_with_fault_tolerance(
+        self,
+        operation_coro: Callable[..., Awaitable[Any]],
+        operation_type: str,
+        peer_id: str,
+        *args,
+        **kwargs,
+    ) -> Dict[str, Any]:
+        try:
+            result = await operation_coro(*args, **kwargs)
+            self.failures[peer_id] = 0
+            return {"success": True, "result": result}
+        except Exception as e:
+            self.failures[peer_id] += 1
+            return {"success": False, "error": str(e)}

--- a/ultimate_agent/network/p2p/quantum_crypto.py
+++ b/ultimate_agent/network/p2p/quantum_crypto.py
@@ -1,0 +1,47 @@
+"""Simplified quantum encryption utilities."""
+
+import hashlib
+import hmac
+import secrets
+from typing import Dict
+
+from painet_common.protocol.messages import QuantumEncryptedPayload
+
+
+class QuantumEncryptionProtocol:
+    """Basic XOR + HMAC based encryption"""
+
+    def __init__(self, node_id: str):
+        self.node_id = node_id
+        self.keys: Dict[str, bytes] = {}
+
+    def _ensure_key(self, peer_id: str) -> bytes:
+        if peer_id not in self.keys:
+            self.keys[peer_id] = secrets.token_bytes(32)
+        return self.keys[peer_id]
+
+    def quantum_key_distribution(self, peer_id: str) -> str:
+        self.keys[peer_id] = secrets.token_bytes(32)
+        return peer_id
+
+    def quantum_encrypt(self, data: bytes, peer_id: str) -> QuantumEncryptedPayload:
+        key = self._ensure_key(peer_id)
+        encrypted = bytes(b ^ key[i % len(key)] for i, b in enumerate(data))
+        signature = hmac.new(key, data, hashlib.sha256).hexdigest()
+        return QuantumEncryptedPayload(
+            encrypted_data=encrypted.hex(),
+            quantum_signature=signature,
+            entanglement_id=peer_id,
+            original_type="",
+            nonce=secrets.token_hex(8),
+            sequence_number=0,
+        )
+
+    def quantum_decrypt(self, payload: QuantumEncryptedPayload, peer_id: str) -> bytes:
+        key = self._ensure_key(peer_id)
+        encrypted = bytes.fromhex(payload.encrypted_data)
+        data = bytes(b ^ key[i % len(key)] for i, b in enumerate(encrypted))
+        expected = hmac.new(key, data, hashlib.sha256).hexdigest()
+        if expected != payload.quantum_signature:
+            raise ValueError("HMAC mismatch")
+        return data

--- a/ultimate_agent/network/p2p/quantum_enhanced_p2p.py
+++ b/ultimate_agent/network/p2p/quantum_enhanced_p2p.py
@@ -1,0 +1,51 @@
+"""Quantum enhanced P2P manager (simplified)."""
+
+import asyncio
+import json
+import uuid
+from typing import Any, Dict, List
+
+from painet_common.protocol.messages import MessageType
+from .quantum_crypto import QuantumEncryptionProtocol
+from .adaptive_routing import CSPAdaptiveRouting
+from .fault_tolerance import CSPFaultTolerance
+
+
+class P2PMessage:
+    def __init__(self, msg_type: MessageType, sender_id: str, data: Any):
+        self.message_id = str(uuid.uuid4())
+        self.type = msg_type
+        self.sender_id = sender_id
+        self.data = data
+
+    def serialize(self) -> bytes:
+        return json.dumps({
+            "message_id": self.message_id,
+            "type": self.type.value,
+            "sender_id": self.sender_id,
+            "data": self.data,
+        }).encode()
+
+
+class QuantumEnhancedP2PManager:
+    def __init__(self, node_id: str):
+        self.node_id = node_id
+        self.quantum = QuantumEncryptionProtocol(node_id)
+        self.routing = CSPAdaptiveRouting(node_id)
+        self.fault = CSPFaultTolerance(node_id)
+        self.connected_peers: Dict[str, Dict[str, Any]] = {}
+
+    async def start_network(self):
+        pass
+
+    async def stop_network(self):
+        pass
+
+    async def send_quantum_encrypted_message(self, target_node: str, message_data: Dict[str, Any]) -> bool:
+        msg = P2PMessage(MessageType.INFERENCE_REQUEST, self.node_id, message_data)
+        encrypted = self.quantum.quantum_encrypt(msg.serialize(), target_node)
+        async def dummy_send():
+            await asyncio.sleep(0)
+            return True
+        result = await self.fault.execute_with_fault_tolerance(dummy_send, "send", target_node)
+        return result.get("success", False)

--- a/ultimate_agent/network/quantum_p2p_bridge.py
+++ b/ultimate_agent/network/quantum_p2p_bridge.py
@@ -1,0 +1,27 @@
+"""Bridge for integrating quantum P2P manager with the agent."""
+
+from typing import Any, Dict
+
+from .p2p.quantum_enhanced_p2p import QuantumEnhancedP2PManager
+
+
+class QuantumP2PBridge:
+    def __init__(self, agent: Any):
+        self.agent = agent
+        self.manager: QuantumEnhancedP2PManager | None = None
+
+    async def start(self) -> bool:
+        self.manager = QuantumEnhancedP2PManager("quantum-" + getattr(self.agent, "agent_id", "agent"))
+        await self.manager.start_network()
+        return True
+
+    async def stop(self):
+        if self.manager:
+            await self.manager.stop_network()
+            self.manager = None
+
+    async def send_quantum_message(self, target_node: str, message_data: Dict[str, Any]) -> Dict[str, Any]:
+        if not self.manager:
+            return {"success": False, "error": "not running"}
+        success = await self.manager.send_quantum_encrypted_message(target_node, message_data)
+        return {"success": success}

--- a/ultimate_agent/requirements.txt
+++ b/ultimate_agent/requirements.txt
@@ -64,3 +64,13 @@ configparser>=5.3.0
 ollama>=0.1.7
 aiohttp>=3.8.0
 GPUtil>=1.4.0  # Optional: GPU monitoring
+
+# Quantum P2P Dependencies
+cryptography>=41.0.0
+pycryptodome>=3.18.0
+aiohttp>=3.8.0
+websockets>=11.0.0
+prometheus-client>=0.17.0
+uvloop>=0.17.0; sys_platform != "win32"
+pydantic[dotenv]>=2.0.0
+pytest-asyncio>=0.21.0

--- a/ultimate_agent/tests/unit/test_local_ai.py
+++ b/ultimate_agent/tests/unit/test_local_ai.py
@@ -6,7 +6,10 @@ from pathlib import Path
 # Add Ultimate Agent to path
 sys.path.insert(0, str(Path(__file__).parent))
 
-async def test_local_ai():
+def test_local_ai():
+    asyncio.run(run_test())
+
+async def run_test():
     print("🧪 Testing Local AI Integration...")
     
     try:
@@ -55,4 +58,4 @@ async def test_local_ai():
         traceback.print_exc()
 
 if __name__ == "__main__":
-    asyncio.run(test_local_ai())
+    asyncio.run(run_test())


### PR DESCRIPTION
## Summary
- add basic protocol definitions for quantum P2P
- implement simple quantum crypto, routing and fault-tolerance modules
- provide a minimal quantum-enhanced P2P manager and bridge
- expose new modules and add dependency list
- update async test to run without pytest-asyncio

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6860831cea8883289ba2f26a29468bc0