### PR TITLE
Add P2P example with hello world

### DIFF
--- a/ultimate_agent/examples/__init__.py
+++ b/ultimate_agent/examples/__init__.py
@@ -1,1 +1,5 @@
-"""Package initialization."""
+"""Example scripts for Ultimate Agent."""
+
+from .p2p_hello_world import main as p2p_hello_world  # noqa: F401
+
+__all__ = ["p2p_hello_world"]

--- a/ultimate_agent/examples/p2p_hello_world.py
+++ b/ultimate_agent/examples/p2p_hello_world.py
@@ -1,0 +1,49 @@
+#!/usr/bin/env python3.11
+"""Simple example showing two peers exchanging a message."""
+
+import asyncio
+import time
+
+from ultimate_agent.network.p2p import QuantumEnhancedP2PManager, MessageType
+
+
+async def main() -> None:
+    # Create two local P2P managers
+    alice = QuantumEnhancedP2PManager("alice", bind_port=0)
+    bob = QuantumEnhancedP2PManager("bob", bind_port=0)
+
+    await alice.start_network()
+    await bob.start_network()
+
+    # Prepare a message handler on Bob's side
+    async def handle_message(message: dict, sender: str) -> None:
+        print(f"Bob received from {sender}: {message['data']['text']}")
+
+    bob.message_handlers[MessageType.INFERENCE_REQUEST] = handle_message
+
+    # Manually connect peers over TCP
+    reader_ab, writer_ab = await asyncio.open_connection("127.0.0.1", bob.bind_port)
+    alice.connected_peers["bob"] = {
+        "writer": writer_ab,
+        "connected_at": time.time(),
+        "last_seen": time.time(),
+    }
+
+    reader_ba, writer_ba = await asyncio.open_connection("127.0.0.1", alice.bind_port)
+    bob.connected_peers["alice"] = {
+        "writer": writer_ba,
+        "connected_at": time.time(),
+        "last_seen": time.time(),
+    }
+
+    await alice.send_quantum_encrypted_message("bob", {"text": "Hello world"})
+
+    # Give Bob a moment to process
+    await asyncio.sleep(0.2)
+
+    await alice.stop_network()
+    await bob.stop_network()
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/ultimate_agent/readme.md
+++ b/ultimate_agent/readme.md
@@ -133,6 +133,29 @@ curl -X POST http://localhost:8080/api/start_task \
   -d '{"type": "neural_network_training"}'
 ```
 
+### **P2P Hello World Example**
+
+This quick demo shows two peers exchanging a message using the quantum P2P module.
+Python **3.11** is recommended.
+
+```bash
+# Create a virtual environment
+python3.11 -m venv venv
+source venv/bin/activate
+
+# Install dependencies
+pip install -r requirements.txt
+
+# Run the example
+python -m ultimate_agent.examples.p2p_hello_world
+```
+
+To run the test suite afterwards:
+
+```bash
+python -m pytest
+```
+
 ---
 
 ## ⚙️ **Configuration**


### PR DESCRIPTION
## Summary
- add a simple `p2p_hello_world` example demonstrating two nodes sending an encrypted message
- expose the example in the `examples` package
- document how to run the example and how to run the tests with Python 3.11

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68608be8dfb0832882b67b51fd09315b